### PR TITLE
Align the VDC connectors at the same place as on the LibreBoard

### DIFF
--- a/emberone.kicad_pcb
+++ b/emberone.kicad_pcb
@@ -17903,7 +17903,7 @@
 	(footprint "emberone:7770-screw-terminal"
 		(layer "F.Cu")
 		(uuid "5a3b5824-75e0-4edd-83c7-998a65d5c157")
-		(at 166 85)
+		(at 166.006118 84.767704)
 		(property "Reference" "J1"
 			(at 5 0 0)
 			(unlocked yes)
@@ -41726,7 +41726,7 @@
 	(footprint "emberone:7770-screw-terminal"
 		(layer "F.Cu")
 		(uuid "da4dced0-7fa1-4814-b168-36971a9ac6cd")
-		(at 187 85)
+		(at 187.016378 84.775714)
 		(property "Reference" "J2"
 			(at 5 0 0)
 			(unlocked yes)
@@ -104001,43 +104001,6 @@
 				(bold yes)
 			)
 			(justify bottom)
-		)
-	)
-	(dimension
-		(type orthogonal)
-		(layer "Edge.Cuts")
-		(uuid "0891c7f3-d223-4fd2-81aa-9d30c088d460")
-		(pts
-			(xy 117.5 83.5) (xy 163.5 81)
-		)
-		(height -12.5)
-		(orientation 0)
-		(format
-			(prefix "")
-			(suffix "")
-			(units 3)
-			(units_format 1)
-			(precision 4)
-		)
-		(style
-			(thickness 0.1)
-			(arrow_length 1.27)
-			(text_position_mode 0)
-			(arrow_direction outward)
-			(extension_height 0.58642)
-			(extension_offset 0.5)
-			(keep_text_aligned yes)
-		)
-		(gr_text "46.0000 mm"
-			(at 140.5 69.85 0)
-			(layer "Edge.Cuts")
-			(uuid "0891c7f3-d223-4fd2-81aa-9d30c088d460")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
 		)
 	)
 	(segment

--- a/emberone.kicad_pcb
+++ b/emberone.kicad_pcb
@@ -17903,7 +17903,7 @@
 	(footprint "emberone:7770-screw-terminal"
 		(layer "F.Cu")
 		(uuid "5a3b5824-75e0-4edd-83c7-998a65d5c157")
-		(at 166 84.75)
+		(at 166 85)
 		(property "Reference" "J1"
 			(at 5 0 0)
 			(unlocked yes)
@@ -103789,8 +103789,8 @@
 		)
 	)
 	(gr_circle
-		(center 166.81 92.69)
-		(end 168.56 92.69)
+		(center 165.75 92.69)
+		(end 167.5 92.69)
 		(stroke
 			(width 0.4)
 			(type default)
@@ -103800,8 +103800,8 @@
 		(uuid "0a2398ea-b490-41fd-acbc-d420e092547e")
 	)
 	(gr_circle
-		(center 195.2787 92.74)
-		(end 197.0287 92.74)
+		(center 187 92.74)
+		(end 188.75 92.74)
 		(stroke
 			(width 0.4)
 			(type default)
@@ -103978,7 +103978,7 @@
 		)
 	)
 	(gr_text "-"
-		(at 195.3087 93.78 0)
+		(at 187.03 93.78 0)
 		(layer "F.SilkS")
 		(uuid "dd9420aa-185d-41a2-9274-55b04a429756")
 		(effects
@@ -103991,7 +103991,7 @@
 		)
 	)
 	(gr_text "+"
-		(at 166.84 93.73 0)
+		(at 165.78 93.73 0)
 		(layer "F.SilkS")
 		(uuid "dee7321d-afdd-42fb-bc50-0877cfa327c1")
 		(effects

--- a/emberone.kicad_pcb
+++ b/emberone.kicad_pcb
@@ -156,7 +156,6 @@
 			(psnegative no)
 			(psa4output no)
 			(plot_black_and_white yes)
-			(plotinvisibletext no)
 			(sketchpadsonfab no)
 			(plotpadnumbers no)
 			(hidednponfab no)
@@ -17904,13 +17903,13 @@
 	(footprint "emberone:7770-screw-terminal"
 		(layer "F.Cu")
 		(uuid "5a3b5824-75e0-4edd-83c7-998a65d5c157")
-		(at 166.795549 84.75)
+		(at 166 84.75)
 		(property "Reference" "J1"
 			(at 5 0 0)
 			(unlocked yes)
 			(layer "F.SilkS")
 			(hide yes)
-			(uuid "0a092fee-3844-48d9-bc0f-08d5b7a65fc6")
+			(uuid "80be976b-358a-4b7a-8de0-caae9531d618")
 			(effects
 				(font
 					(size 1 1)
@@ -17922,7 +17921,7 @@
 			(at 0 6 0)
 			(unlocked yes)
 			(layer "F.Fab")
-			(uuid "fb1f2a5e-cf78-467d-a49c-0aa9f707ba85")
+			(uuid "44bc4c47-a751-4607-93e0-5e80af4f1db8")
 			(effects
 				(font
 					(size 1 1)
@@ -17934,7 +17933,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "1ab9da16-2e49-44aa-81ab-1d19ed9d7e16")
+			(uuid "a6af0476-c5a0-42a1-8c51-6244d5a01ecf")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17946,7 +17945,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "15d26667-0a4b-451e-b487-492c160f4fe2")
+			(uuid "056c35d2-5dbc-4951-b9d6-bed57e77d0c8")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -41727,13 +41726,13 @@
 	(footprint "emberone:7770-screw-terminal"
 		(layer "F.Cu")
 		(uuid "da4dced0-7fa1-4814-b168-36971a9ac6cd")
-		(at 195.274249 84.8)
+		(at 187 85)
 		(property "Reference" "J2"
 			(at 5 0 0)
 			(unlocked yes)
 			(layer "F.SilkS")
 			(hide yes)
-			(uuid "30cd5f63-e942-4ee4-99ce-bff4ec6a38fe")
+			(uuid "b45eb81e-e057-4253-a72d-36cbe20aca09")
 			(effects
 				(font
 					(size 1 1)
@@ -41745,7 +41744,7 @@
 			(at 0 6 0)
 			(unlocked yes)
 			(layer "F.Fab")
-			(uuid "d6c679f0-5007-44c7-903a-822effabec71")
+			(uuid "d2cebae5-8d26-4fc2-88ce-0a2de70c29e0")
 			(effects
 				(font
 					(size 1 1)
@@ -41757,7 +41756,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "63da4301-dfd8-4d41-90de-c21ad4d89ec7")
+			(uuid "85b113f3-52f3-48c4-a32b-c3e93c7f2cab")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -41769,7 +41768,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3fc2769d-e8ed-433e-ba37-e8c44eb61744")
+			(uuid "b89c1e01-cbbe-4519-9ce7-503da961e554")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -103904,7 +103903,7 @@
 		(uuid "fbb1f27e-5fbd-4ffb-924f-0814b3d29e2c")
 	)
 	(gr_text "100W\n12-24\nVDC"
-		(at 181.25 89.99 0)
+		(at 177 90 0)
 		(layer "F.SilkS")
 		(uuid "020161b5-80f2-48b1-8b2b-0633e2ee208e")
 		(effects
@@ -104002,6 +104001,43 @@
 				(bold yes)
 			)
 			(justify bottom)
+		)
+	)
+	(dimension
+		(type orthogonal)
+		(layer "Edge.Cuts")
+		(uuid "0891c7f3-d223-4fd2-81aa-9d30c088d460")
+		(pts
+			(xy 117.5 83.5) (xy 163.5 81)
+		)
+		(height -12.5)
+		(orientation 0)
+		(format
+			(prefix "")
+			(suffix "")
+			(units 3)
+			(units_format 1)
+			(precision 4)
+		)
+		(style
+			(thickness 0.1)
+			(arrow_length 1.27)
+			(text_position_mode 0)
+			(arrow_direction outward)
+			(extension_height 0.58642)
+			(extension_offset 0.5)
+			(keep_text_aligned yes)
+		)
+		(gr_text "46.0000 mm"
+			(at 140.5 69.85 0)
+			(layer "Edge.Cuts")
+			(uuid "0891c7f3-d223-4fd2-81aa-9d30c088d460")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
 		)
 	)
 	(segment

--- a/emberone.kicad_pro
+++ b/emberone.kicad_pro
@@ -125,6 +125,7 @@
         "solder_mask_bridge": "error",
         "starved_thermal": "error",
         "text_height": "warning",
+        "text_on_edge_cuts": "error",
         "text_thickness": "warning",
         "through_hole_pad_without_hole": "error",
         "too_many_vias": "error",


### PR DESCRIPTION
I tried to put the VDC connectors on the LibreBoard on the exact same position as the connectors on the emberone, unfortunately the position of the CM5 is very fix and prevents me to put place the right connector at the same position.

this PR moves just the connectors a little bit to the right, to a position that I can also put them on the LibreBoard, this way when one builds an enclosure and stacks the emberone and the libreboard the connectors are going to align.